### PR TITLE
Add: global fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typography"
   ],
   "devDependencies": {
+    "@babel/runtime": "^7.22.10",
     "eslint": "^8.28.0",
     "grapesjs-cli": "^3.0.1"
   },

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -1,338 +1,408 @@
-import {html, render} from 'lit-html'
-import {live} from 'lit-html/directives/live.js'
-import { map } from 'lit-html/directives/map.js'
-import {styleMap} from 'lit-html/directives/style-map.js'
-import {ref, createRef} from 'lit-html/directives/ref.js'
+import { html, render } from 'lit-html';
+import { live } from 'lit-html/directives/live.js';
+import { map } from 'lit-html/directives/map.js';
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { ref, createRef } from 'lit-html/directives/ref.js';
 
-const el = document.createElement('div')
-let modal
+const el = document.createElement('div');
+let modal;
 
-export const cmdOpenFonts = 'open-fonts'
+export const cmdOpenFonts = 'open-fonts';
 
 /**
  * Constants
  */
-const LS_FONTS = 'silex-loaded-fonts-list'
+const LS_FONTS = 'silex-loaded-fonts-list';
 
 /**
  * Module variables
  */
-let _fontsList
-let fonts
-let defaults = []
-let globalFont
+let _fontsList;
+let fonts;
+let defaults = [];
+let globalFont;
 
 /**
  * Load available fonts only once per session
  * Use local storage
  */
 try {
-    _fontsList = JSON.parse(localStorage.getItem(LS_FONTS))
-} catch(e) {
-    console.error('Could not get fonts from local storage:', e)
+  _fontsList = JSON.parse(localStorage.getItem(LS_FONTS));
+} catch (e) {
+  console.error('Could not get fonts from local storage:', e);
 }
 
 /**
  * Promised wait function
  */
 async function wait(ms = 0) {
-    return new Promise(resolve => setTimeout(() => resolve(), ms))
+  return new Promise((resolve) => setTimeout(() => resolve(), ms));
 }
 
 /**
  * When the dialog is opened
  */
 async function loadFonts(editor) {
-    fonts = structuredClone(editor.getModel().get('fonts') || [])
+  fonts = structuredClone(editor.getModel().get('fonts') || []);
 }
 
 /**
  * When the dialog is closed
  */
 function saveFonts(editor, opts) {
-    const model = editor.getModel()
+  const model = editor.getModel();
 
-    // Store the modified fonts
-    model.set('fonts', fonts)
+  // Store the modified fonts
+  model.set('fonts', fonts);
 
-    // Update the HTML head with style sheets to load
-    updateHead(editor, fonts)
+  // Update the HTML head with style sheets to load
+  updateHead(editor, fonts);
 
-    // Update the "font family" dropdown
-    updateUi(editor, fonts, opts)
+  // Update the "font family" dropdown
+  updateUi(editor, fonts, opts);
 
-    // Save website if auto save is on
-    model.set('changesCount', editor.getDirtyCount() + 1)
+  // Save website if auto save is on
+  model.set('changesCount', editor.getDirtyCount() + 1);
 }
 
 /**
  * Load the available fonts from google
  */
 async function loadFontList(url) {
-    _fontsList = _fontsList ?? (await (await fetch(url)).json())?.items
-    localStorage.setItem(LS_FONTS, JSON.stringify(_fontsList))
-    await wait() // let the dialog open
-    return _fontsList
+  _fontsList = _fontsList ?? (await (await fetch(url)).json())?.items;
+  localStorage.setItem(LS_FONTS, JSON.stringify(_fontsList));
+  await wait(); // let the dialog open
+  return _fontsList;
 }
 
 export const fontsDialogPlugin = (editor, opts) => {
-    defaults = editor.StyleManager.getBuiltIn('font-family').options
-    if(!opts.api_key) throw new Error(editor.I18n.t('grapesjs-fonts.You must provide Google font api key'))
-    editor.Commands.add(cmdOpenFonts, {
-        /* eslint-disable-next-line */
-        run: (_, sender) => {
-            modal = editor.Modal.open({
-                title: editor.I18n.t('grapesjs-fonts.Fonts'),
-                content: '',
-                attributes: { class: 'fonts-dialog' },
-            })
-                .onceClose(() => {
-                    editor.stopCommand(cmdOpenFonts) // apparently this is needed to be able to run the command several times
-                })
-            modal.setContent(el)
-            loadFonts(editor)
-            displayFonts(editor, opts, [])
-            loadFontList('https://www.googleapis.com/webfonts/v1/webfonts?key=' + opts.api_key)
-                .then(fontsList => { // the run command will terminate before this is done, better for performance
-                    displayFonts(editor, opts, fontsList)
-                    const form = el.querySelector('form')
-                    form.onsubmit = event => {
-                        event.preventDefault()
-                        saveFonts(editor, opts)
-                        editor.stopCommand(cmdOpenFonts)
-                    }
-                    form.querySelector('input')?.focus()
-                })
-            return modal
-        },
-        stop: () => {
-            modal.close()
-        },
-    })
-    // add fonts to the website
-    editor.on('storage:start:store', (data) => {
-        data.fonts = editor.getModel().get('fonts')
-    })
-    editor.on('storage:end:load', (data) => {
-        const fonts = data.fonts || []
-        editor.getModel().set('fonts', fonts)
-        setTimeout(() => {
-            updateHead(editor, fonts)
-            updateUi(editor, fonts, opts)
-        })
-    })
-}
+  defaults = editor.StyleManager.getBuiltIn('font-family').options;
+  if (!opts.api_key)
+    throw new Error(
+      editor.I18n.t('grapesjs-fonts.You must provide Google font api key'),
+    );
+  editor.Commands.add(cmdOpenFonts, {
+    /* eslint-disable-next-line */
+    run: (_, sender) => {
+      modal = editor.Modal.open({
+        title: editor.I18n.t('grapesjs-fonts.Fonts'),
+        content: '',
+        attributes: { class: 'fonts-dialog' },
+      }).onceClose(() => {
+        editor.stopCommand(cmdOpenFonts); // apparently this is needed to be able to run the command several times
+      });
+      modal.setContent(el);
+      loadFonts(editor);
+      displayFonts(editor, opts, []);
+      loadFontList(
+        'https://www.googleapis.com/webfonts/v1/webfonts?key=' + opts.api_key,
+      ).then((fontsList) => {
+        // the run command will terminate before this is done, better for performance
+        displayFonts(editor, opts, fontsList);
+        const form = el.querySelector('form');
+        form.onsubmit = (event) => {
+          event.preventDefault();
+          saveFonts(editor, opts);
+          editor.stopCommand(cmdOpenFonts);
+        };
+        form.querySelector('input')?.focus();
+      });
+      return modal;
+    },
+    stop: () => {
+      modal.close();
+    },
+  });
+  // add fonts to the website
+  editor.on('storage:start:store', (data) => {
+    data.fonts = editor.getModel().get('fonts');
+  });
+  editor.on('storage:end:load', (data) => {
+    const fonts = data.fonts || [];
+    editor.getModel().set('fonts', fonts);
+    setTimeout(() => {
+      updateHead(editor, fonts);
+      updateUi(editor, fonts, opts);
+    });
+  });
+};
 
 function match(hay, s) {
-    const regExp = new RegExp(s, 'i')
-    return hay.search(regExp) !== -1
+  const regExp = new RegExp(s, 'i');
+  return hay.search(regExp) !== -1;
 }
 
-const searchInputRef = createRef()
-const fontRef = createRef()
+const searchInputRef = createRef();
+const fontRef = createRef();
 
 function displayFonts(editor, config, fontsList) {
-    const searchInput = searchInputRef.value
-    const activeFonts = fontsList.filter(f => match(f.family, searchInput?.value || ''))
-    searchInput?.focus()
-    function findFont(font) {
-        return fontsList.find(f => font.name === f.family)
-    }
-    render(html`
-    <form class="silex-form grapesjs-fonts">
-      <div class="silex-form__group">
-        <div class="silex-bar">
-          <input
-            style=${styleMap({
-        width: '100%',
-    })}
-            placeholder="${editor.I18n.t('grapesjs-fonts.Search')}"
-            type="text"
-            ${ref(searchInputRef)}
-            @keydown=${() => {
-        //(fontRef.value as HTMLSelectElement).selectedIndex = 0
-        setTimeout(() => displayFonts(editor, config, fontsList))
-    }}/>
-          <select
-            style=${styleMap({
-        width: '150px',
-    })}
-            ${ref(fontRef)}
-          >
-            ${ map(activeFonts, f => html`
-              <option value=${f['family']}>${f['family']}</option>
-            `)}
-          </select>
-          <button class="silex-button"
-            ?disabled=${!fontRef.value || activeFonts.length === 0}
-            type="button" @click=${() => {
-        addFont(
-            editor,
-            config,
-            fonts,
-            activeFonts[fontRef.value.selectedIndex]
-        )
-        displayFonts(editor, config, fontsList)
-    }}>
-            ${editor.I18n.t('grapesjs-fonts.Add font')}
-          </button>
+  const searchInput = searchInputRef.value;
+  const activeFonts = fontsList.filter((f) =>
+    match(f.family, searchInput?.value || ''),
+  );
+  searchInput?.focus();
+  function findFont(font) {
+    return fontsList.find((f) => font.name === f.family);
+  }
+  render(
+    html`
+      <form class="silex-form grapesjs-fonts">
+        <div class="silex-form__group">
+          <div class="silex-bar">
+            <input
+              style=${styleMap({
+                width: '100%',
+              })}
+              placeholder="${editor.I18n.t('grapesjs-fonts.Search')}"
+              type="text"
+              ${ref(searchInputRef)}
+              @keydown=${() => {
+                //(fontRef.value as HTMLSelectElement).selectedIndex = 0
+                setTimeout(() => displayFonts(editor, config, fontsList));
+              }}
+            />
+            <select
+              style=${styleMap({
+                width: '150px',
+              })}
+              ${ref(fontRef)}
+            >
+              ${map(
+                activeFonts,
+                (f) => html`
+                  <option value=${f['family']}>${f['family']}</option>
+                `,
+              )}
+            </select>
+            <button
+              class="silex-button"
+              ?disabled=${!fontRef.value || activeFonts.length === 0}
+              type="button"
+              @click=${() => {
+                addFont(
+                  editor,
+                  config,
+                  fonts,
+                  activeFonts[fontRef.value.selectedIndex],
+                );
+                displayFonts(editor, config, fontsList);
+              }}
+            >
+              ${editor.I18n.t('grapesjs-fonts.Add font')}
+            </button>
+          </div>
         </div>
-      </div>
-      <hr/>
-      <div
-        class="silex-form__element">
-        <h2>${editor.I18n.t('grapesjs-fonts.Installed fonts')}</h2>
-        <ol class="silex-list">
-        ${ map(fonts, f => html`
-          <li>
-            <div class="silex-list__item__header">
-              <h4>${f.name}</h4>
-            </div>
-            <div class="silex-list__item__body">
-              <fieldset class="silex-group--simple full-width">
-                <legend>CSS rules</legend>
-                <input
-                  class="full-width"
-                  type="text"
-                  name="name"
-                  .value=${live(f.value)}
-                  @change=${e => {
-        updateRules(editor, fonts, f, e.target.value)
-        displayFonts(editor, config, fontsList)
-    }}
-                />
-              </fieldset>
-              <fieldset class="silex-group--simple full-width">
-                <legend>Variants</legend>
-                ${ map(
-        // keep only variants which are letters, no numbers
-        // FIXME: we need the weights
-        findFont(f)?.variants.filter(v => v.replace(/[a-z]/g, '') === ''),
-        v => html`
-                  <div>
-                    <input
-                      id=${ f.name + v }
-                      type="checkbox"
-                      value=${v}
-                      ?checked=${f.variants?.includes(v)}
-                      @change=${e => {
-        updateVariant(editor, fonts, f, v, e.target.checked)
-        displayFonts(editor, config, fontsList)
-    }}
-                    /><label for=${ f.name + v }>${v}</label>
+        <hr />
+        <div class="silex-form__element">
+          <h2>${editor.I18n.t('grapesjs-fonts.Installed fonts')}</h2>
+          <ol class="silex-list">
+            ${map(
+              fonts,
+              (f) => html`
+                <li>
+                  <div class="silex-list__item__header">
+                    <h4>${f.name}</h4>
                   </div>
-                `)}
-              </fieldset>
-            </div>
-            <div class="silex-list__item__footer">
-              <button class="silex-button" type="button" @click=${() => {
-        removeFont(editor, fonts, f)
-        displayFonts(editor, config, fontsList)
-    }}>${editor.I18n.t('grapesjs-fonts.Remove')}</button>
-            </div>
-          </li>
-        `) }
-        </ol>
-        <h2>${editor.I18n.t('grapesjs-fonts.Global Font')}</h2>
+                  <div class="silex-list__item__body">
+                    <fieldset class="silex-group--simple full-width">
+                      <legend>CSS rules</legend>
+                      <input
+                        class="full-width"
+                        type="text"
+                        name="name"
+                        .value=${live(f.value)}
+                        @change=${(e) => {
+                          updateRules(editor, fonts, f, e.target.value);
+                          displayFonts(editor, config, fontsList);
+                        }}
+                      />
+                    </fieldset>
+                    <fieldset class="silex-group--simple full-width">
+                      <legend>Variants</legend>
+                      ${map(
+                        // keep only variants which are letters, no numbers
+                        // FIXME: we need the weights
+                        findFont(f)?.variants.filter(
+                          (v) => v.replace(/[a-z]/g, '') === '',
+                        ),
+                        (v) => html`
+                          <div>
+                            <input
+                              id=${f.name + v}
+                              type="checkbox"
+                              value=${v}
+                              ?checked=${f.variants?.includes(v)}
+                              @change=${(e) => {
+                                updateVariant(
+                                  editor,
+                                  fonts,
+                                  f,
+                                  v,
+                                  e.target.checked,
+                                );
+                                displayFonts(editor, config, fontsList);
+                              }}
+                            /><label for=${f.name + v}>${v}</label>
+                          </div>
+                        `,
+                      )}
+                    </fieldset>
+                  </div>
+                  <div class="silex-list__item__footer">
+                    <button
+                      class="silex-button"
+                      type="button"
+                      @click=${() => {
+                        removeFont(editor, fonts, f);
+                        displayFonts(editor, config, fontsList);
+                      }}
+                    >
+                      ${editor.I18n.t('grapesjs-fonts.Remove')}
+                    </button>
+                  </div>
+                </li>
+              `,
+            )}
+          </ol>
+          <h2>${editor.I18n.t('grapesjs-fonts.Global Font')}</h2>
           <select
             name="fonts"
             @change=${(e) => {
-              globalFont = e.target.value
-              console.log(globalFont)
+              globalFont = e.target.value;
+              console.log(globalFont);
             }}
           >
             <option value="null">select</option>
-            ${map(fonts, (font) => html` <option value="${font.value}">${font.name}</option> `)}
+            ${map(
+              fonts,
+              (font) => html`
+                <option value="${font.value}">${font.name}</option>
+              `,
+            )}
           </select>
-      </div>
-      <footer>
-        <input class="silex-button" type="button" @click=${() => editor.stopCommand(cmdOpenFonts)} value="${editor.I18n.t('grapesjs-fonts.Cancel')}">
-        <input class="silex-button" type="submit" value="${editor.I18n.t('grapesjs-fonts.Save')}">
-      </footer>
-    </form>
-  `, el)
+        </div>
+        <footer>
+          <input
+            class="silex-button"
+            type="button"
+            @click=${() => editor.stopCommand(cmdOpenFonts)}
+            value="${editor.I18n.t('grapesjs-fonts.Cancel')}"
+          />
+          <input
+            class="silex-button"
+            type="submit"
+            value="${editor.I18n.t('grapesjs-fonts.Save')}"
+          />
+        </footer>
+      </form>
+    `,
+    el,
+  );
 }
 
 function addFont(editor, config, fonts, font) {
-    const name = font.family
-    const value = `"${font.family}", ${font.category}`
-    fonts.push({ name, value, variants: [] })
+  const name = font.family;
+  const value = `"${font.family}", ${font.category}`;
+  fonts.push({ name, value, variants: [] });
 }
 
 function removeFont(editor, fonts, font) {
-    const idx = fonts.findIndex(f => f === font)
-    fonts.splice(idx, 1)
+  const idx = fonts.findIndex((f) => f === font);
+  fonts.splice(idx, 1);
 }
 
 function insertOnce(doc, attr, tag, attributes) {
-    if(!doc.head.querySelector(`[${ attr }]`)) {
-        insert(doc, attr, tag, attributes)
-    }
+  if (!doc.head.querySelector(`[${attr}]`)) {
+    insert(doc, attr, tag, attributes);
+  }
 }
 function insert(doc, attr, tag, attributes) {
-    const el = doc.createElement(tag)
-    el.setAttribute(attr, '')
-    Object.keys(attributes).forEach(key => el.setAttribute(key, attributes[key]))
-    doc.head.appendChild(el)
+  const el = doc.createElement(tag);
+  el.setAttribute(attr, '');
+  Object.keys(attributes).forEach((key) =>
+    el.setAttribute(key, attributes[key]),
+  );
+  doc.head.appendChild(el);
 }
 function removeAll(doc, attr) {
-    Array.from(doc.head.querySelector(`[${ attr }]`))
-        .forEach((el) => el.remove())
+  Array.from(doc.head.querySelector(`[${attr}]`)).forEach((el) => el.remove());
 }
-const GOOGLE_APIS_ATTR = 'data-silex-google-apis'
-const GSTATIC_ATTR = 'data-silex-gstatic'
-const GOOGLE_FONTS_ATTR = 'data-silex-gstatic'
+const GOOGLE_APIS_ATTR = 'data-silex-google-apis';
+const GSTATIC_ATTR = 'data-silex-gstatic';
+const GOOGLE_FONTS_ATTR = 'data-silex-gstatic';
 function updateHead(editor, fonts) {
-    const doc = editor.Canvas.getDocument()
-    insertOnce(doc, GOOGLE_APIS_ATTR, 'link', { 'href': 'https://fonts.googleapis.com', 'rel': 'preconnect' })
-    insertOnce(doc, GSTATIC_ATTR, 'link', { 'href': 'https://fonts.gstatic.com', 'rel': 'preconnect', 'crossorigin': '' })
-    removeAll(doc, GOOGLE_FONTS_ATTR)
+  const doc = editor.Canvas.getDocument();
+  insertOnce(doc, GOOGLE_APIS_ATTR, 'link', {
+    href: 'https://fonts.googleapis.com',
+    rel: 'preconnect',
+  });
+  insertOnce(doc, GSTATIC_ATTR, 'link', {
+    href: 'https://fonts.gstatic.com',
+    rel: 'preconnect',
+    crossorigin: '',
+  });
+  removeAll(doc, GOOGLE_FONTS_ATTR);
 
-    // FIXME: how to use google fonts v2?
-    // google fonts V2: https://developers.google.com/fonts/docs/css2
-    //fonts.forEach(f => {
-    //  const prefix = f.variants.length ? ':' : ''
-    //  const variants = prefix + f.variants.map(v => {
-    //    const weight = parseInt(v)
-    //    const axis = v.replace(/\d+/g, '')
-    //    return `${axis},wght@${weight}`
-    //  }).join(',')
-    //  insert(doc, GOOGLE_FONTS_ATTR, 'link', { 'href': `https://fonts.googleapis.com/css2?family=${f.name.replace(/ /g, '+')}${variants}&display=swap`, 'rel': 'stylesheet' })
-    //})
+  // FIXME: how to use google fonts v2?
+  // google fonts V2: https://developers.google.com/fonts/docs/css2
+  //fonts.forEach(f => {
+  //  const prefix = f.variants.length ? ':' : ''
+  //  const variants = prefix + f.variants.map(v => {
+  //    const weight = parseInt(v)
+  //    const axis = v.replace(/\d+/g, '')
+  //    return `${axis},wght@${weight}`
+  //  }).join(',')
+  //  insert(doc, GOOGLE_FONTS_ATTR, 'link', { 'href': `https://fonts.googleapis.com/css2?family=${f.name.replace(/ /g, '+')}${variants}&display=swap`, 'rel': 'stylesheet' })
+  //})
 
-    // Google fonts v1
-    // https://developers.google.com/fonts/docs/getting_started#a_quick_example
-    fonts.forEach(f => {
-        const prefix = f.variants.length ? ':' : ''
-        const variants = prefix + f.variants.map(v => v.replace(/\d+/g, '')).filter(v => !!v).join(',')
-        insert(doc, GOOGLE_FONTS_ATTR, 'link', { 'href': `https://fonts.googleapis.com/css?family=${f.name.replace(/ /g, '+')}${variants}&display=swap`, 'rel': 'stylesheet' })
-    })
+  // Google fonts v1
+  // https://developers.google.com/fonts/docs/getting_started#a_quick_example
+  fonts.forEach((f) => {
+    const prefix = f.variants.length ? ':' : '';
+    const variants =
+      prefix +
+      f.variants
+        .map((v) => v.replace(/\d+/g, ''))
+        .filter((v) => !!v)
+        .join(',');
+    insert(doc, GOOGLE_FONTS_ATTR, 'link', {
+      href: `https://fonts.googleapis.com/css?family=${f.name.replace(
+        / /g,
+        '+',
+      )}${variants}&display=swap`,
+      rel: 'stylesheet',
+    });
+  });
 
-    // only if user select any global font
-    if (globalFont !== undefined) {
-        // add global font in css of intire HTML DOM
-      doc.head.insertAdjacentHTML('beforeend', `<style>*{font-family: ${globalFont}}</style>`)
-      // add font to style while exporting
-      editor.Css.setRule('*', { 'font-family': `${globalFont}` })
-    }
+  // only if user select any global font
+  if (globalFont !== undefined) {
+    // add global font in css of intire HTML DOM
+    doc.head.insertAdjacentHTML(
+      'beforeend',
+      `<style>*{font-family: ${globalFont}}</style>`,
+    );
+    // add font to style while exporting
+    editor.Css.setRule('*', { 'font-family': `${globalFont}` });
+  }
 }
 
 function updateUi(editor, fonts, opts) {
-    const styleManager = editor.StyleManager
-    const fontProperty = styleManager.getProperty('typography', 'font-family')
-    if (opts.preserveDefaultFonts) {
-        fonts = defaults.concat(fonts)
-    } else if (fonts.length === 0) {
-        fonts = defaults
-    }
-    fontProperty.setOptions(fonts)
+  const styleManager = editor.StyleManager;
+  const fontProperty = styleManager.getProperty('typography', 'font-family');
+  if (opts.preserveDefaultFonts) {
+    fonts = defaults.concat(fonts);
+  } else if (fonts.length === 0) {
+    fonts = defaults;
+  }
+  fontProperty.setOptions(fonts);
 }
 
 function updateRules(editor, fonts, font, value) {
-    font.value = value
+  font.value = value;
 }
 function updateVariant(editor, fonts, font, variant, checked) {
-    const has = font.variants?.includes(variant)
-    if(has && !checked) font.variants = font.variants.filter(v => v !== variant)
-    else if(!has && checked) font.variants.push(variant)
+  const has = font.variants?.includes(variant);
+  if (has && !checked)
+    font.variants = font.variants.filter((v) => v !== variant);
+  else if (!has && checked) font.variants.push(variant);
 }

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -20,6 +20,7 @@ const LS_FONTS = 'silex-loaded-fonts-list'
 let _fontsList
 let fonts
 let defaults = []
+let globalFont
 
 /**
  * Load available fonts only once per session
@@ -232,6 +233,17 @@ function displayFonts(editor, config, fontsList) {
           </li>
         `) }
         </ol>
+        <h2>${editor.I18n.t('grapesjs-fonts.Global Font')}</h2>
+          <select
+            name="fonts"
+            @change=${(e) => {
+              globalFont = e.target.value
+              console.log(globalFont)
+            }}
+          >
+            <option value="null">select</option>
+            ${map(fonts, (font) => html` <option value="${font.value}">${font.name}</option> `)}
+          </select>
       </div>
       <footer>
         <input class="silex-button" type="button" @click=${() => editor.stopCommand(cmdOpenFonts)} value="${editor.I18n.t('grapesjs-fonts.Cancel')}">
@@ -295,6 +307,11 @@ function updateHead(editor, fonts) {
         const variants = prefix + f.variants.map(v => v.replace(/\d+/g, '')).filter(v => !!v).join(',')
         insert(doc, GOOGLE_FONTS_ATTR, 'link', { 'href': `https://fonts.googleapis.com/css?family=${f.name.replace(/ /g, '+')}${variants}&display=swap`, 'rel': 'stylesheet' })
     })
+
+    // add global font in css of intire HTML DOM
+  doc.head.insertAdjacentHTML('beforeend', `<style>*{font-family: ${globalFont}}</style>`)
+  // add font to style while exporting
+  editor.Css.setRule('*', { 'font-family': `${globalFont}` })
 }
 
 function updateUi(editor, fonts, opts) {

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -308,10 +308,13 @@ function updateHead(editor, fonts) {
         insert(doc, GOOGLE_FONTS_ATTR, 'link', { 'href': `https://fonts.googleapis.com/css?family=${f.name.replace(/ /g, '+')}${variants}&display=swap`, 'rel': 'stylesheet' })
     })
 
-    // add global font in css of intire HTML DOM
-  doc.head.insertAdjacentHTML('beforeend', `<style>*{font-family: ${globalFont}}</style>`)
-  // add font to style while exporting
-  editor.Css.setRule('*', { 'font-family': `${globalFont}` })
+    // only if user select any global font
+    if (globalFont !== undefined) {
+        // add global font in css of intire HTML DOM
+      doc.head.insertAdjacentHTML('beforeend', `<style>*{font-family: ${globalFont}}</style>`)
+      // add font to style while exporting
+      editor.Css.setRule('*', { 'font-family': `${globalFont}` })
+    }
 }
 
 function updateUi(editor, fonts, opts) {

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -8,6 +8,7 @@ export default {
         'Save': 'Save',
         'Cancel': 'Cancel',
         'Installed fonts': 'Installed fonts',
+        'Global Font': 'Global Font'
     },
 }
 

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -9,6 +9,7 @@ export default {
         'Save': 'Enregistrer',
         'Cancel': 'Annuler',
         'Installed fonts': 'Polices installées',
+        'Global Font': 'Police globale'
     },
 }
 

--- a/src/locale/ptbr.js
+++ b/src/locale/ptbr.js
@@ -8,5 +8,6 @@ export default {
         'Save': 'Salvar',
         'Cancel': 'Cancelar',
         'Installed fonts': 'Fontes instaladas',
+        'Global Font': 'Fonte global'
     },
 }


### PR DESCRIPTION
If users wish to incorporate a global font into their website, they currently face an issue with the "grapesjs-fonts" plugin. This is because users are required to manually add the font to each part of their site. With the assistance of this PR, users will be able to seamlessly add a global font to the entire page.

here is the [issue](https://github.com/silexlabs/grapesjs-fonts/issues/7)

Also added the i18n translation for the changes.

here is a demo ;)
![grapesjs-font-2023-08-17_10 10 35](https://github.com/silexlabs/grapesjs-fonts/assets/68537640/63f53681-97f1-4be8-a859-2ac169b9f15b)
