### PR TITLE
Fix fonts not loading after page switch

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -132,7 +132,7 @@ export const fontsDialogPlugin = (editor, opts) => {
     // When the page changes, update the dom
     editor.on('page', () => {
         // FIXME: remove this timeout which is a workaround for issues with fonts loading after page change
-        setTimeout(() => refresh(editor, opts), 1000)
+        setTimeout(() => refresh(editor, opts), 50)
     })
 }
 


### PR DESCRIPTION
For some reason, when the page event is triggered, the `head` element returned by `editor.Canvas.getDocument().head` is not the same as in the iframe.

I'm not sure about the root cause yet, it seems like the Canvas is not ready at that time. Might be an issue with GrapesJS, or maybe a wrong assumption in this library?

In any case, a quick workaround is to delay event handling a little.